### PR TITLE
Make syntax highlighting work when there is no space after the assignment colon

### DIFF
--- a/syntax/less.vim
+++ b/syntax/less.vim
@@ -9,11 +9,11 @@ runtime! after/syntax/css/*.vim
 
 syn case ignore
 
-syn region lessDefinition transparent matchgroup=cssBraces start='{' end='}' contains=css.*Attr,css.*Prop,cssComment,cssValue.*,cssColor,cssTagName,cssPseudoClass,cssUrl,cssImportant,cssError,cssStringQ,cssStringQQ,cssFunction,cssUnicodeEscape,lessDefinition,lessComment,lessClassChar,lessVariable,lessMixinChar,lessAmpersandChar,lessFunction,@cssColors
+syn region lessDefinition transparent matchgroup=cssBraces start='{' end='}' contains=lessAssignment,css.*Attr,css.*Prop,cssComment,cssValue.*,cssColor,cssTagName,cssPseudoClass,cssUrl,cssImportant,cssError,cssStringQ,cssStringQQ,cssFunction,cssUnicodeEscape,lessDefinition,lessComment,lessClassChar,lessVariable,lessMixinChar,lessAmpersandChar,lessFunction,@cssColors
 
 syn match lessVariable "@[[:alnum:]_-]\+" contained 
-syn match lessVariable "@[[:alnum:]_-]\+" nextgroup=lessVariableAssignment skipwhite
-syn match lessVariableAssignment ":" contained nextgroup=lessVariableValue skipwhite
+syn match lessVariable "@[[:alnum:]_-]\+" nextgroup=lessAssignment skipwhite
+syn match lessAssignment ":" contained nextgroup=lessVariableValue skipwhite
 syn match lessVariableValue ".*;"me=e-1 contained contains=lessVariable,lessOperator,lessDefault,cssValue.*,@cssColors "me=e-1 means that the last char of the pattern is not highlighted
 
 syn match lessOperator "+" contained


### PR DESCRIPTION
In order to make property definitions work where no spaces
have been inserted after the colon, lessVariableAssignment
has to be added to the lessDefiniton region.
However, since in this context it is not always a _variable_
assignment it has been renamed to lessAssignment.
