### PR TITLE
Revert the 'no space after colon' commit to fix issue #10

### DIFF
--- a/syntax/less.vim
+++ b/syntax/less.vim
@@ -9,11 +9,11 @@ runtime! after/syntax/css/*.vim
 
 syn case ignore
 
-syn region lessDefinition transparent matchgroup=cssBraces start='{' end='}' contains=lessAssignment,css.*Attr,css.*Prop,cssComment,cssValue.*,cssColor,cssTagName,cssIdentifier,cssPseudoClass,cssUrl,cssImportant,cssError,cssStringQ,cssStringQQ,cssFunction,cssUnicodeEscape,lessDefinition,lessComment,lessClassChar,lessVariable,lessMixinChar,lessAmpersandChar,lessFunction,@cssColors
+syn region lessDefinition transparent matchgroup=cssBraces start='{' end='}' contains=css.*Attr,css.*Prop,cssComment,cssValue.*,cssColor,cssTagName,cssPseudoClass,cssUrl,cssImportant,cssError,cssStringQ,cssStringQQ,cssFunction,cssUnicodeEscape,lessDefinition,lessComment,lessClassChar,lessVariable,lessMixinChar,lessAmpersandChar,lessFunction,@cssColors
 
 syn match lessVariable "@[[:alnum:]_-]\+" contained 
-syn match lessVariable "@[[:alnum:]_-]\+" nextgroup=lessAssignment skipwhite
-syn match lessAssignment ":" contained nextgroup=lessVariableValue skipwhite
+syn match lessVariable "@[[:alnum:]_-]\+" nextgroup=lessVariableAssignment skipwhite
+syn match lessVariableAssignment ":" contained nextgroup=lessVariableValue skipwhite
 syn match lessVariableValue ".*;"me=e-1 contained contains=lessVariable,lessOperator,lessDefault,cssValue.*,@cssColors "me=e-1 means that the last char of the pattern is not highlighted
 
 syn match lessOperator "+" contained


### PR DESCRIPTION
Now you can have multiple definitions on one line but there remains the issue with having to use a space after the colon in a definition.

There is also another commit in there which allows ids in a less definition.
