### PR TITLE
-'s as word chars: allow dashes in identifiers

### DIFF
--- a/ftplugin/less.vim
+++ b/ftplugin/less.vim
@@ -12,6 +12,7 @@ let b:did_ftplugin = 1
 
 let b:undo_ftplugin = "setl cms< def< inc< inex< ofu< sua<"
 
+setlocal iskeyword+=-
 setlocal commentstring=//\ %s
 setlocal define=^\\s*\\%(@mixin\\\|=\\)
 setlocal includeexpr=substitute(v:fname,'\\%(.*/\\\|^\\)\\zs','_','')


### PR DESCRIPTION
this makes w,b,e,ciw, et cetera more convenient, since identifiers in
LESS (just like in CSS) may have dashes
