### PR TITLE
Set comments option to a suitable value

### DIFF
--- a/ftplugin/less.vim
+++ b/ftplugin/less.vim
@@ -18,6 +18,7 @@ setlocal define=^\\s*\\%(@mixin\\\|=\\)
 setlocal includeexpr=substitute(v:fname,'\\%(.*/\\\|^\\)\\zs','_','')
 setlocal omnifunc=csscomplete#CompleteCSS
 setlocal suffixesadd=.less
+setlocal comments=s1:/*,mb:*,ex:*/
 
 let &l:include = '^\s*@import\s\+\%(url(\)\=["'']\='
 


### PR DESCRIPTION
Set 'comments' to the same as CSS. This avoids a ">" leader being added when pressing enter at the end of a line starting with >, as in

```
ul.special {
    > li {
        color: red;
    }
}
```

Before this patch pressing enter at the end of the > li { line annoyingly puts a > at the start of the next line.
