### PR TITLE
Changes the vimrc save command to use <Leader>

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ in `after/syntax/css.vim` or `after/syntax/css/*.vim`.
 ### Map
 .less to .css , lessc is required.
 
-    nnoremap ,m :w <BAR> !lessc % > %:t:r.css<CR><space>
+    nnoremap <Leader>m :w <BAR> !lessc % > %:t:r.css<CR><space>
 
 
 ## Credits


### PR DESCRIPTION
- The README directed users to enter a command in their vimrc that began
  with ",".  Clearly this was intended to be the user's <Leader> key,
  which is commonly ",".
