### PR TITLE
Highlight html style tags with type=text/less

### DIFF
--- a/after/syntax/html.vim
+++ b/after/syntax/html.vim
@@ -1,0 +1,22 @@
+if !exists("g:less_html_style_tags")
+  let g:less_html_style_tags = 1
+endif
+
+if !g:less_html_style_tags
+  finish
+endif
+
+" Unset (but preserve) so that less will run.
+let s:pre_less_cur_syn = b:current_syntax
+unlet b:current_syntax
+
+" Inspired by code from github.com/kchmck/vim-coffee-script
+" and the html syntax file included with vim 7.4.
+
+syn include @htmlLess syntax/less.vim
+
+" We have to explicitly add to htmlHead (containedin) as that region specifies 'contains'.
+syn region lessStyle start=+<style [^>]*type *=[^>]*text/less[^>]*>+ keepend end=+</style>+ contains=@htmlLess,htmlTag,htmlEndTag,htmlCssStyleComment,@htmlPreproc containedin=htmlHead
+
+" Reset since 'less' isn't really the current_syntax.
+let b:current_syntax = s:pre_less_cur_syn


### PR DESCRIPTION
This will highlight less inside style tags (with type="text/less") when editing html.
It can be disabled with a global var.

Thankfully it was pretty simple to add.
What do you think?
