### PR TITLE
Add protection around the current_syntax storing

### DIFF
--- a/after/syntax/html.vim
+++ b/after/syntax/html.vim
@@ -7,8 +7,10 @@ if !g:less_html_style_tags
 endif
 
 " Unset (but preserve) so that less will run.
-let s:pre_less_cur_syn = b:current_syntax
-unlet b:current_syntax
+if exists("b:current_syntax")
+   let s:pre_less_cur_syn = b:current_syntax
+   unlet b:current_syntax
+endif
 
 " Inspired by code from github.com/kchmck/vim-coffee-script
 " and the html syntax file included with vim 7.4.
@@ -19,4 +21,6 @@ syn include @htmlLess syntax/less.vim
 syn region lessStyle start=+<style [^>]*type *=[^>]*text/less[^>]*>+ keepend end=+</style>+ contains=@htmlLess,htmlTag,htmlEndTag,htmlCssStyleComment,@htmlPreproc containedin=htmlHead
 
 " Reset since 'less' isn't really the current_syntax.
-let b:current_syntax = s:pre_less_cur_syn
+if exists("s:pre_less_cur_syn")
+   let b:current_syntax = s:pre_less_cur_syn
+endif


### PR DESCRIPTION
Experienced an error with `b:current_syntax` not being set when I opened a Markdown file.  Seems to be caused by how the environment is when the less syntax is inherited.  This just adds guards for the variable not being set.  Does not effect highlighting in less files.
