### PR TITLE
Compatibility issues

### DIFF
--- a/ftplugin/less.vim
+++ b/ftplugin/less.vim
@@ -19,7 +19,7 @@ setlocal includeexpr=substitute(v:fname,'\\%(.*/\\\|^\\)\\zs','_','')
 setlocal omnifunc=csscomplete#CompleteCSS
 setlocal suffixesadd=.less
 setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,://
-setlocal fo=jcroql
+setlocal fo=croql
 
 let &l:include = '^\s*@import\s\+\%(url(\)\=["'']\='
 


### PR DESCRIPTION
Older vim versions do not accept the j formatoptions' flag
